### PR TITLE
Add keys for Mechanic

### DIFF
--- a/showDist.roboFontExt/info.plist
+++ b/showDist.roboFontExt/info.plist
@@ -20,5 +20,9 @@
 	<real>1409847156.227813</real>
 	<key>version</key>
 	<string>1.0</string>
+	<key>repository</key>
+	<string>frankrolf/showDist</string>
+	<key>extensionPath</key>
+	<string>showDist.roboFontExt</string>
 </dict>
 </plist>


### PR DESCRIPTION
Here's the two keys that needed to be added to `info.plist` in order to get it to work.

`repository` needed to be set to the name of the repository here on github (with your username): `frankrolf/showDist`

`extensionPath` just needed to be set to `showDist.roboFontExt`, because your sensations file is in the root of the repository, and not in a subdirectory.

After you accept the pull request:
- Pull the change into your local repository
- Open the Mechanic interface in RoboFont and select the "Register" tab
- Click "Import" and select the updated extension file inside the repository (this should fill in all of the fields)
- Click "Register", and if there are no errors the Extension should be immediately available to install from the "Install" tab

Let me know if there are any other issues or if something doesn't make sense.
