### PR TITLE
Use inDarkMode to find the proper color.

### DIFF
--- a/showDist.roboFontExt/lib/showDist.py
+++ b/showDist.roboFontExt/lib/showDist.py
@@ -9,7 +9,7 @@ import math
 import AppKit
 import vanilla
 from mojo.subscriber import Subscriber, registerGlyphEditorSubscriber
-from mojo.UI import getDefault
+from mojo.UI import getDefault, inDarkMode
 
 
 def get_BCP_base(bcp):
@@ -127,8 +127,11 @@ class ShowDistSubscriber(Subscriber):
 
     def build(self):
         glyphEditor = self.getGlyphEditor()
-
-        text_color = getDefault('glyphViewPointCoordinateColor')
+        if  inDarkMode():
+            colorName = 'glyphViewPointCoordinateColor.dark'
+        else:
+            colorName = 'glyphViewPointCoordinateColor'
+        text_color = getDefault(colorName)
         text_color_float = tuple(float(item) for item in text_color)
         text_size = getDefault('textFontSize')
 


### PR DESCRIPTION
This will use `glyphViewPointCoordinateColor.dark` in dark mode, and `glyphViewPointCoordinateColor` in non-dark-mode. Note: this is not smart enough to respond if the dark mode change happens with RF open.